### PR TITLE
Fix platform in sceneObservation bug

### DIFF
--- a/src/engine/core/MarioForwardModel.java
+++ b/src/engine/core/MarioForwardModel.java
@@ -175,9 +175,9 @@ public class MarioForwardModel {
 	    case 15:
 		return OBS_COIN;
 	    // Jump through platforms
-	    case 43:
 	    case 44:
 	    case 45:
+	    case 46:
 		return OBS_PLATFORM;
 	    }
 	    return OBS_NONE;


### PR DESCRIPTION
Fixed the bug when calling getMarioSceneObservation with detail level 1, where the middle tiles of a platform weren't considered as part of OBS_PLATFORM.